### PR TITLE
Pin external action `actions/upload-artifact` version

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,7 +39,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
Referring an external action by version name is flagged with Pinned-Dependencies by OSSF Scorecard as the tag used may change if a minor or patch release is added. Dependabot is able to manage these dependencies using the hash value.