### PR TITLE
Pin external actions versions to commit hash value

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -10,8 +10,8 @@ jobs:
   coverity:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: vapier/coverity-scan-action@v1
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - uses: vapier/coverity-scan-action@2068473c7bdf8c2fb984a6a40ae76ee7facd7a85 # v1.8.0
       with:
         project: Template-Repo
         email: ${{ secrets.COVERITY_SCAN_EMAIL }}


### PR DESCRIPTION
This change should resolve the OSSF Scorcard flag about pinning dependencies.