### PR TITLE
Enable Result Publishing

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          publish_results: false
+          publish_results: true
 
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 [![Coverity scan build status](https://img.shields.io/coverity/scan/30204.svg)](https://scan.coverity.com/projects/template-repo)
 [![CodeQL](https://github.com/codeplaysoftware/Template-Repo/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/codeplaysoftware/Template-Repo/actions/workflows/github-code-scanning/codeql)
-[![Scorecard supply-chain security](https://github.com/codeplaysoftware/Template-Repo/actions/workflows/scorecard.yml/badge.svg)](https://github.com/codeplaysoftware/Template-Repo/actions/workflows/scorecard.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/{owner}/{repo}/badge)](https://scorecard.dev/viewer/?uri=github.com/{owner}/{repo})

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 [![Coverity scan build status](https://img.shields.io/coverity/scan/30204.svg)](https://scan.coverity.com/projects/template-repo)
 [![CodeQL](https://github.com/codeplaysoftware/Template-Repo/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/codeplaysoftware/Template-Repo/actions/workflows/github-code-scanning/codeql)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/{owner}/{repo}/badge)](https://scorecard.dev/viewer/?uri=github.com/{owner}/{repo})
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/codeplaysoftware/Template-Repo/badge)](https://scorecard.dev/viewer/?uri=github.com/codeplaysoftware/Template-Repo)

--- a/README.md
+++ b/README.md
@@ -2,4 +2,5 @@
 
 [![Coverity scan build status](https://img.shields.io/coverity/scan/30204.svg)](https://scan.coverity.com/projects/template-repo)
 [![CodeQL](https://github.com/codeplaysoftware/Template-Repo/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/codeplaysoftware/Template-Repo/actions/workflows/github-code-scanning/codeql)
+[![Scorecard supply-chain security](https://github.com/codeplaysoftware/Template-Repo/actions/workflows/scorecard.yml/badge.svg)](https://github.com/codeplaysoftware/Template-Repo/actions/workflows/scorecard.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/codeplaysoftware/Template-Repo/badge)](https://scorecard.dev/viewer/?uri=github.com/codeplaysoftware/Template-Repo)


### PR DESCRIPTION
This PR enables OSSF result publishing so we can have something like this:

https://securityscorecards.dev/viewer/?uri=github.com/tensorflow/tensorflow